### PR TITLE
Added module pinning capability

### DIFF
--- a/CppProperties.json
+++ b/CppProperties.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "name": "x64-Release",
+      "includePath": [
+        "${env.INCLUDE}",
+        "${workspaceRoot}\\**"
+      ],
+      "defines": [
+        "WIN32",
+        "NDEBUG",
+        "UNICODE",
+        "_UNICODE"
+      ],
+      "intelliSenseMode": "windows-msvc-x64"
+    }
+  ]
+}

--- a/injector/arguments.h
+++ b/injector/arguments.h
@@ -1,0 +1,28 @@
+#ifndef ARGUMENTS_H
+#define ARGUMENTS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define mSetArg(s_args, arg) \
+    ((s_args) |= (int)(arg))
+
+#define mCheckArg(s_args, arg) \
+    (((s_args) & (int)(arg)) == (int)(arg))
+
+enum Args{
+    file    = 1 << 0,      // -f
+    output  = 1 << 1,      // -o
+    help    = 1 << 2
+};
+
+typedef struct ProgramArguments {
+    uint8_t s_args;
+} PROGRAMARGUMENTS, * PPROGRAMARGUMENTS;
+
+// Function prototypes
+void SetArgBit(PPROGRAMARGUMENTS args, enum Args arg);
+bool CheckArgBit(const PPROGRAMARGUMENTS args, enum Args arg);
+
+
+#endif //ARGUMENTS_H

--- a/injector/injector.c
+++ b/injector/injector.c
@@ -1,21 +1,54 @@
 #include <stdio.h>
 #include <windows.h>
 
+#include "usage.h"
+#include "arguments.h"
+
 int main(int argc, char** argv)
 {
+    //
+    // Argument handling
+    //
     if (argc < 2)
     {
-        printf("Usage: gftrace.exe <file> <params>\n");
+        fprintf(stdout, "%s", USAGE);
         return 1;
     }
 
     LPSTR CmdLine = GetCommandLineA();
-    LPSTR ProcCmdLine = strchr(CmdLine, 0x20);
+
+    PROGRAMARGUMENTS args;
+	ZeroMemory(&args, sizeof(PROGRAMARGUMENTS));
+    for (unsigned int i = 1; i < (ULONG)argc; i++) {
+        //
+        // Iterate over argv and search for option.
+        //
+        if (strstr(argv[i], "-f")) {
+            mSetArg(args.s_args, file);
+            CmdLine = argv[i + 1];
+        }
+        if (strstr(argv[i], "-o")) mSetArg(args.s_args, output);
+        if (strstr(argv[i], "--help") || strstr(argv[i], "-h")) {
+            mSetArg(args.s_args, help);
+            fprintf(stdout, "%s", USAGE);
+            return 0;
+        }
+    }
 
     //
-    // Ignore all the spaces next to argv[0]
+    // Check if "-f" was used at all.
     //
-    while (*++ProcCmdLine == 0x20);
+    if (!mCheckArg(args.s_args, file)) {
+        fprintf(stdout, "%s", INVALID);
+        return 1;
+    }
+
+    // No valid arguments were inputed
+    if (args.s_args == 0) {
+        fprintf(stderr, "%s", INVALID);
+        return 1;
+    }
+
 
     PROCESS_INFORMATION ProcessInformation;
     STARTUPINFOA StartupInfo;
@@ -27,7 +60,7 @@ int main(int argc, char** argv)
     //
     // Create the target process in suspended state.
     //
-    if (!CreateProcessA(NULL, ProcCmdLine, NULL, NULL, FALSE, CREATE_SUSPENDED, NULL, NULL, &StartupInfo, &ProcessInformation))
+    if (!CreateProcessA(NULL, CmdLine, NULL, NULL, FALSE, CREATE_SUSPENDED, NULL, NULL, &StartupInfo, &ProcessInformation))
     {
         printf("[!] Failed to create the target process.\n[!] Error code: %u\n", GetLastError());
         return 1;

--- a/injector/injector.vcxproj
+++ b/injector/injector.vcxproj
@@ -145,6 +145,10 @@
   <ItemGroup>
     <ClCompile Include="injector.c" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="arguments.h" />
+    <ClInclude Include="usage.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/injector/injector.vcxproj.filters
+++ b/injector/injector.vcxproj.filters
@@ -19,4 +19,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="usage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="arguments.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/injector/usage.h
+++ b/injector/usage.h
@@ -1,0 +1,13 @@
+#ifndef USAGE_H
+#define USAGE_H
+
+#define INVALID "[-] Invalid arguments, please type \"gftrace.exe --help\"\n"
+
+#define USAGE   "[+] Usage: gftrace.exe [options]\n\n"                                              \
+                "Options:\n"                                                                        \
+                "           -f      <file>      The executable to be traced. (required)\n"          \
+				"           -o      <output>    The file which receives gftrace's output.\n"        \
+                "           --help              Display this message.\n"                            \
+                "\n[i] Example: gftrace.exe -f malware.exe -o trace.txt\n"
+
+#endif //USAGE_H

--- a/tracer/dllmain.c
+++ b/tracer/dllmain.c
@@ -11,9 +11,9 @@ Init()
     HMODULE hSafeCheck = NULL;
 
 #ifdef _WIN64
-    const WCHAR* moduleName = L"gftrace.dll";
+    const WCHAR* moduleName = TEXT("gftrace.dll");
 #else
-    const WCHAR* moduleName = L"gftrace32.dll";
+    const WCHAR* moduleName = TEXT("gftrace32.dll");
 #endif
 
     BOOL IsPinned = GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN, moduleName, &hSafeCheck);

--- a/tracer/dllmain.c
+++ b/tracer/dllmain.c
@@ -5,15 +5,14 @@ VOID
 Init()
 {
     //
-	// Pin our module, so it does not get unloaded from the target process (with FreeLibrary for example).
-	// https://blog.syscall.party/2020/04/03/tampering-with-zooms-anti-tampering-library.html
+	// Pin our module, so it does not get unloaded from the target process (with FreeLibrary() for example).
 	//
     HMODULE hSafeCheck = NULL;
 
 #ifdef _WIN64
-    const WCHAR* moduleName = TEXT("gftrace.dll");
+    const LPCWSTR moduleName = TEXT("gftrace.dll");
 #else
-    const WCHAR* moduleName = TEXT("gftrace32.dll");
+    const LPCWSTR moduleName = TEXT("gftrace32.dll");
 #endif
 
     BOOL IsPinned = GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN, moduleName, &hSafeCheck);

--- a/tracer/dllmain.c
+++ b/tracer/dllmain.c
@@ -5,6 +5,25 @@ VOID
 Init()
 {
     //
+	// Pin our module, so it does not get unloaded from the target process (with FreeLibrary for example).
+	// https://blog.syscall.party/2020/04/03/tampering-with-zooms-anti-tampering-library.html
+	//
+    HMODULE hSafeCheck = NULL;
+
+#ifdef _WIN64
+    const WCHAR* moduleName = L"gftrace.dll";
+#else
+    const WCHAR* moduleName = L"gftrace32.dll";
+#endif
+
+    BOOL IsPinned = GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN, moduleName, &hSafeCheck);
+
+    if (!IsPinned || hSafeCheck == NULL)
+    {
+        PrintWinError("Failed to pin module, might be vulnerable to unloading.", GetLastError());
+    }
+
+    //
     // Get kernel32.dll module base address.
     //
     HMODULE ModuleBase = GetModuleHandleW(L"kernel32.dll");

--- a/tracer/pe.c
+++ b/tracer/pe.c
@@ -139,7 +139,6 @@ GetExportAddr(
 
 	PLDR_DATA_TABLE_ENTRY CurrentModule = NULL;
 	PLIST_ENTRY CurrentEntry = Peb->Ldr->InLoadOrderModuleList.Flink;
-	FARPROC ExportAddr;
 
 	//
 	// Go through each loaded module and try to find the target export address using the given export name.
@@ -147,7 +146,7 @@ GetExportAddr(
 	while (CurrentEntry != &Peb->Ldr->InLoadOrderModuleList && CurrentEntry != NULL)
 	{
 		CurrentModule = CONTAINING_RECORD(CurrentEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
-		ExportAddr = ResolveExportAddr((ULONG_PTR)CurrentModule->DllBase, ExportName);
+		FARPROC ExportAddr = ResolveExportAddr((ULONG_PTR)CurrentModule->DllBase, ExportName);
 
 		if (ExportAddr != NULL)
 		{

--- a/tracer/utils.c
+++ b/tracer/utils.c
@@ -217,10 +217,7 @@ IsSameStr(
 		char c1 = Str1[i];
 		char c2 = Str2[i];
 
-		c1 = tolower(c1);
-		c2 = tolower(c2);
-
-		if (c1 != c2)
+		if ((c1 | 0x20) != (c2 | 0x20))
 		{
 			return FALSE;
 		}


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandleexw

By using GetModuleHandleExW with GET_MODULE_HANDLE_EX_FLAG_PIN parameter, we prevent any unexpected unload on our module.
This can prevent malware from unloading foreign modules within its own address space.

Also, on https://github.com/estr3llas/gftrace/commit/b5fdc2aa150fa11694876ac44804f994f506b000 there is a little improvement on the function's implementation, so we do not have to assign c1 and c2 a new value every iteration.

